### PR TITLE
Fix padding in post filter popover

### DIFF
--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -15,8 +15,9 @@ import { useCurrentUser } from '../common/withUser';
 
 export const filteringStyles = (theme: ThemeType) => ({
   paddingLeft: 16,
-  paddingTop: 12,
+  paddingTop: 18,
   paddingRight: 16,
+  paddingBottom: 16,
   width: 500,
   marginBottom: -4,
   ...theme.typography.commentStyle,


### PR DESCRIPTION
More bottom padding needed, plus a bit more on top.

<img width="555" alt="Screen Shot 2022-03-12 at 10 59 43 AM" src="https://user-images.githubusercontent.com/11878478/158031345-7898b082-238d-4279-960f-1f776e937004.png">
