### PR TITLE
Unify blockquote styling

### DIFF
--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -138,6 +138,7 @@ const createLWTheme = (theme: ThemeType) => {
       },
       display1: {
         color: grey[800],
+        // color: theme.palette.primary.main,
         fontSize: '2rem',
         marginTop: '1em'
       },
@@ -169,21 +170,22 @@ const createLWTheme = (theme: ThemeType) => {
       },
       blockquote: {
         fontWeight: 400,
-        paddingTop: spacingUnit*2,
+        paddingTop: spacingUnit*1.5,
         paddingRight: spacingUnit*2,
-        paddingBottom: spacingUnit*2,
+        paddingBottom: spacingUnit*1.5,
         paddingLeft: spacingUnit*2,
         borderLeft: `solid 3px ${grey[300]}`,
-        margin: 0,
+        // margin: 0,
+        marginLeft: spacingUnit*3,
       },
       commentBlockquote: {
         fontWeight: 400,
-        paddingTop: spacingUnit,
-        paddingRight: spacingUnit*3,
-        paddingBottom: spacingUnit,
-        paddingLeft: spacingUnit*2,
+        paddingTop: spacingUnit*1,
+        paddingRight: spacingUnit*1.5,
+        paddingBottom: spacingUnit*1,
+        paddingLeft: spacingUnit*1.5,
         borderLeft: `solid 3px ${grey[300]}`,
-        margin: 0,
+        // margin: 0,
         marginLeft: spacingUnit*1.5,
       },
       codeblock: {


### PR DESCRIPTION
Comment blockquotes - less paddingLeft, more paddingBottom -> better gestalt

<img width="1440" alt="Screen Shot 2022-03-23 at 5 39 50 PM" src="https://user-images.githubusercontent.com/11878478/159820546-feec1987-c174-4c59-beda-63bfa0b103c9.png">
<img width="1440" alt="Screen Shot 2022-03-23 at 5 39 59 PM" src="https://user-images.githubusercontent.com/11878478/159820552-4cfdfaca-df92-44e5-b457-fb2caee28ec9.png">

Article blockquotes - unify with comment blockquotes, emphasize the difference from the author's text. When quoting a passage, increased padding is standard in books. Also adds dynamism in long texts.

<img width="1440" alt="Screen Shot 2022-03-23 at 5 40 08 PM" src="https://user-images.githubusercontent.com/11878478/159820557-c967dcc8-1e5f-4d1f-bac4-50271f215a24.png">
<img width="1440" alt="Screen Shot 2022-03-23 at 5 40 16 PM" src="https://user-images.githubusercontent.com/11878478/159820561-f08036d5-3752-4b01-b4b4-9bbf5255c9a6.png">

