### PR TITLE
Update color of section titles from grey to red

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -20,6 +20,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   title: {
     ...sectionTitleStyle(theme),
+    color: theme.palette.primary.main,
     display: "inline",
     marginRight: "auto"
   },

--- a/packages/lesswrong/components/common/SectionTitle.tsx
+++ b/packages/lesswrong/components/common/SectionTitle.tsx
@@ -20,7 +20,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop: 0
   },
   title: {
-    ...sectionTitleStyle(theme)
+    ...sectionTitleStyle(theme),
+    color: theme.palette.primary.main,
   },
   children: {
     ...theme.typography.commentStyle,


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2022-03-23 at 6 23 00 PM" src="https://user-images.githubusercontent.com/11878478/159823911-6683e878-c870-4616-8723-b9bc8f8e2c09.png">


More life, less monotony:

<img width="1440" alt="Screen Shot 2022-03-23 at 6 23 09 PM" src="https://user-images.githubusercontent.com/11878478/159823916-c40c134e-318b-47da-8894-a4904a802d8f.png">

