### PR TITLE
Improve padding on Recent Discussion cards

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -67,9 +67,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     opacity: 0,
   },
   content :{
-    marginLeft: 4,
-    marginRight: 4,
-    paddingBottom: 1
+    marginTop: 16,
+    marginLeft: 8,
+    marginRight: 20,
+    paddingBottom: 12,
   },
   commentsList: {
     marginTop: 12,
@@ -82,12 +83,13 @@ const styles = (theme: ThemeType): JssStyles => ({
     }
   },
   post: {
-    paddingTop: 18,
-    paddingLeft: 16,
-    paddingRight: 16,
+    paddingTop: 20,
+    // paddingBottom: 20,
+    paddingLeft: 20,
+    paddingRight: 20,
     background: "white",
     borderRadius: 3,
-    marginBottom:4
+    // marginBottom: 4,
   },
   titleAndActions: {
     display: "flex",


### PR DESCRIPTION
The changes are most visible around comments.

<img width="1440" alt="Screen Shot 2022-03-23 at 7 01 51 PM" src="https://user-images.githubusercontent.com/11878478/159827921-d549aa35-87f2-460d-8500-28dacfd86adb.png">
<img width="1440" alt="Screen Shot 2022-03-23 at 7 01 58 PM" src="https://user-images.githubusercontent.com/11878478/159827923-b63baeb9-2259-4025-a584-41b17ee94a95.png">

