### PR TITLE
Improve typographical contrast of article titles

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -9,9 +9,10 @@ export const postPageTitleStyles = theme => ({
   ...theme.typography.display3,
   ...theme.typography.postStyle,
   ...theme.typography.headerStyle,
+  lineHeight: 1.25,
   marginTop: 0,
   marginLeft: 0,
-  marginBottom: forumTypeSetting.get() === 'EAForum' ? theme.spacing.unit : 0,
+  marginBottom: forumTypeSetting.get() === 'EAForum' ? theme.spacing.unit : 8,
   color: theme.palette.text.primary,
   [theme.breakpoints.down('sm')]: {
     fontSize: '2.5rem',

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -98,8 +98,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     flexGrow: 1,
     marginTop: 0,
     marginBottom: 8,
+    marginRight: 8,
     display: "block",
-    fontSize: "1.75rem",
+    fontSize: "1.9rem",
+    lineHeight: 1.25,
   },
   actions: {
     "& .PostsPageActions-icon": {

--- a/packages/lesswrong/themes/pfTheme.ts
+++ b/packages/lesswrong/themes/pfTheme.ts
@@ -60,7 +60,7 @@ const theme = createLWTheme({
   typography: {
     fontDownloads: [
       "https://fonts.googleapis.com/css?family=Mukta:300,400,500,600",
-      "https://fonts.googleapis.com/css?family=Source+Serif+Pro:300,400,500,600",
+      "https://fonts.googleapis.com/css2?family=Source+Serif+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap",
     ],
     fontFamily: sansSerifStack,
     postStyle: {
@@ -68,6 +68,7 @@ const theme = createLWTheme({
     },
     headerStyle: {
       fontFamily: serifStack,
+      fontWeight: 700,
     },
     caption: {
       // captions should be relative to their surrounding content, so they are unopinionated about fontFamily and use ems instead of rems


### PR DESCRIPTION
Article:

<img width="1440" alt="Screen Shot 2022-03-23 at 7 38 32 PM" src="https://user-images.githubusercontent.com/11878478/159833622-3ceeaebd-e8ac-4dee-a1e6-b4f3b3425b79.png">

<img width="1440" alt="Screen Shot 2022-03-23 at 7 38 38 PM" src="https://user-images.githubusercontent.com/11878478/159833629-3cb7fb62-3736-467d-a415-c7fc9f976560.png">



Recent Discussion:

<img width="1440" alt="Screen Shot 2022-03-23 at 7 54 25 PM" src="https://user-images.githubusercontent.com/11878478/159833668-0dc8b934-83f7-4f18-b988-dd7eb4af5160.png">

<img width="1440" alt="Screen Shot 2022-03-23 at 7 54 30 PM" src="https://user-images.githubusercontent.com/11878478/159833673-b9ce8779-1e83-4376-9458-d2503cc6d9b2.png">